### PR TITLE
ProbeReader (sam as Probe but accepts io.Reader)

### DIFF
--- a/probe_reader.go
+++ b/probe_reader.go
@@ -1,0 +1,46 @@
+package ffmpeg_go
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os/exec"
+	"time"
+)
+
+// ProbeReader** functions are the same as Probe** but accepting io.Reader instead of fileName
+
+// ProbeReader runs ffprobe passing given reader via stdin and return a JSON representation of the output.
+func ProbeReader(r io.Reader, kwargs ...KwArgs) (string, error) {
+	return ProbeReaderWithTimeout(r, 0, MergeKwArgs(kwargs))
+}
+
+func ProbeReaderWithTimeout(r io.Reader, timeOut time.Duration, kwargs KwArgs) (string, error) {
+	args := KwArgs{
+		"show_format":  "",
+		"show_streams": "",
+		"of":           "json",
+	}
+
+	return ProbeReaderWithTimeoutExec(r, timeOut, MergeKwArgs([]KwArgs{args, kwargs}))
+}
+
+func ProbeReaderWithTimeoutExec(r io.Reader, timeOut time.Duration, kwargs KwArgs) (string, error) {
+	args := ConvertKwargsToCmdLineArgs(kwargs)
+	args = append(args, "-")
+	ctx := context.Background()
+	if timeOut > 0 {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(context.Background(), timeOut)
+		defer cancel()
+	}
+	cmd := exec.CommandContext(ctx, "ffprobe", args...)
+	cmd.Stdin = r
+	buf := bytes.NewBuffer(nil)
+	cmd.Stdout = buf
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+	return string(buf.Bytes()), nil
+}

--- a/probe_reader_test.go
+++ b/probe_reader_test.go
@@ -1,0 +1,20 @@
+package ffmpeg_go
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProbeReader(t *testing.T) {
+	f, err := os.Open(TestInputFile1)
+	assert.Nil(t, err)
+
+	data, err := ProbeReader(f, nil)
+	assert.Nil(t, err)
+	duration, err := probeOutputDuration(data)
+	assert.Nil(t, err)
+	assert.Equal(t, fmt.Sprintf("%f", duration), "7.036000")
+}


### PR DESCRIPTION
New functions were copy-pasted from existed one, but with a slightly different argument list, so it accepts `io.Reader` instead of `fileName string`.

Actual different is that instead of `filename` is set `-`, and `cmd.stdin = reader`

P.S. _possible todo in case if it's approved: refactor it, so we have a new function that can do both fileName/reader, and the old function becomes deprecated and it calls the new one_