### PR TITLE
Move platform-specific code under build tags. Fix blinkind shell window on Windows

### DIFF
--- a/ffmpeg_linux_test.go
+++ b/ffmpeg_linux_test.go
@@ -9,6 +9,19 @@ import (
 func TestCompileWithOptions(t *testing.T) {
 	out := Input("dummy.mp4").Output("dummy2.mp4")
 	cmd := out.Compile(SeparateProcessGroup())
-	assert.Equal(t, cmd.SysProcAttr.Pgid, 0)
+	assert.Equal(t, 0, cmd.SysProcAttr.Pgid)
+	assert.True(t, cmd.SysProcAttr.Setpgid)
+}
+
+func TestGlobalCommandOptions(t *testing.T) {
+	out := Input("dummy.mp4").Output("dummy2.mp4")
+	GlobalCommandOptions = append(GlobalCommandOptions, func(cmd *exec.Cmd) {
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: 0}
+	})
+	defer func() {
+		GlobalCommandOptions = GlobalCommandOptions[0 : len(GlobalCommandOptions)-1]
+	}()
+	cmd := out.Compile()
+	assert.Equal(t, 0, cmd.SysProcAttr.Pgid)
 	assert.True(t, cmd.SysProcAttr.Setpgid)
 }

--- a/ffmpeg_linux_test.go
+++ b/ffmpeg_linux_test.go
@@ -1,0 +1,14 @@
+package ffmpeg_go
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompileWithOptions(t *testing.T) {
+	out := Input("dummy.mp4").Output("dummy2.mp4")
+	cmd := out.Compile(SeparateProcessGroup())
+	assert.Equal(t, cmd.SysProcAttr.Pgid, 0)
+	assert.True(t, cmd.SysProcAttr.Setpgid)
+}

--- a/ffmpeg_test.go
+++ b/ffmpeg_test.go
@@ -277,13 +277,6 @@ func TestCompile(t *testing.T) {
 	assert.Equal(t, out.Compile().Args, []string{"ffmpeg", "-i", "dummy.mp4", "dummy2.mp4"})
 }
 
-func TestCompileWithOptions(t *testing.T) {
-	out := Input("dummy.mp4").Output("dummy2.mp4")
-	cmd := out.Compile(SeparateProcessGroup())
-	assert.Equal(t, cmd.SysProcAttr.Pgid, 0)
-	assert.True(t, cmd.SysProcAttr.Setpgid)
-}
-
 func TestPipe(t *testing.T) {
 
 	width, height := 32, 32

--- a/ffmpeg_windows_test.go
+++ b/ffmpeg_windows_test.go
@@ -1,0 +1,20 @@
+package ffmpeg_go
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompileWithOptions(t *testing.T) {
+	out := Input("dummy.mp4").Output("dummy2.mp4")
+	cmd := out.Compile(func(s *Stream, cmd *exec.Cmd) {
+		if cmd.SysProcAttr == nil {
+			cmd.SysProcAttr = &syscall.SysProcAttr{}
+		}
+		cmd.SysProcAttr.HideWindow = true
+	})
+	assert.Equal(t, true, cmd.SysProcAttr.HideWindow)
+}

--- a/ffmpeg_windows_test.go
+++ b/ffmpeg_windows_test.go
@@ -18,3 +18,18 @@ func TestCompileWithOptions(t *testing.T) {
 	})
 	assert.Equal(t, true, cmd.SysProcAttr.HideWindow)
 }
+
+func TestGlobalCommandOptions(t *testing.T) {
+	out := Input("dummy.mp4").Output("dummy2.mp4")
+	GlobalCommandOptions = append(GlobalCommandOptions, func(cmd *exec.Cmd) {
+		if cmd.SysProcAttr == nil {
+			cmd.SysProcAttr = &syscall.SysProcAttr{}
+		}
+		cmd.SysProcAttr.HideWindow = true
+	})
+	defer func() {
+		GlobalCommandOptions = GlobalCommandOptions[0 : len(GlobalCommandOptions)-1]
+	}()
+	cmd := out.Compile()
+	assert.Equal(t, true, cmd.SysProcAttr.HideWindow)
+}

--- a/probe.go
+++ b/probe.go
@@ -34,6 +34,9 @@ func ProbeWithTimeoutExec(fileName string, timeOut time.Duration, kwargs KwArgs)
 	cmd := exec.CommandContext(ctx, "ffprobe", args...)
 	buf := bytes.NewBuffer(nil)
 	cmd.Stdout = buf
+	for _, option := range GlobalCommandOptions {
+		option(cmd)
+	}
 	err := cmd.Run()
 	if err != nil {
 		return "", err

--- a/run.go
+++ b/run.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -238,15 +237,6 @@ func (s *Stream) ErrorToStdOut() *Stream {
 }
 
 type CompilationOption func(s *Stream, cmd *exec.Cmd)
-
-// SeparateProcessGroup ensures that the command is run in a separate process
-// group. This is useful to enable handling of signals such as SIGINT without
-// propagating them to the ffmpeg process.
-func SeparateProcessGroup() CompilationOption {
-	return func(s *Stream, cmd *exec.Cmd) {
-		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: 0}
-	}
-}
 
 func (s *Stream) SetFfmpegPath(path string) *Stream {
 	s.FfmpegPath = path

--- a/run.go
+++ b/run.go
@@ -236,6 +236,10 @@ func (s *Stream) ErrorToStdOut() *Stream {
 	return s.WithErrorOutput(os.Stdout)
 }
 
+type CommandOption func(cmd *exec.Cmd)
+
+var GlobalCommandOptions = make([]CommandOption, 0)
+
 type CompilationOption func(s *Stream, cmd *exec.Cmd)
 
 func (s *Stream) SetFfmpegPath(path string) *Stream {
@@ -258,6 +262,9 @@ func (s *Stream) Compile(options ...CompilationOption) *exec.Cmd {
 	}
 	for _, option := range options {
 		option(s, cmd)
+	}
+	for _, option := range GlobalCommandOptions {
+		option(cmd)
 	}
 	log.Printf("compiled command: ffmpeg %s\n", strings.Join(args, " "))
 	return cmd

--- a/run_linux.go
+++ b/run_linux.go
@@ -140,3 +140,12 @@ func (s *Stream) RunLinux() error {
 
 	return cmd.Wait()
 }
+
+// SeparateProcessGroup ensures that the command is run in a separate process
+// group. This is useful to enable handling of signals such as SIGINT without
+// propagating them to the ffmpeg process.
+func SeparateProcessGroup() CompilationOption {
+	return func(s *Stream, cmd *exec.Cmd) {
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: 0}
+	}
+}


### PR DESCRIPTION
## Move platform-specific code under build tags; fix corresponding tests
The example `SeparateProcessGroup()` of brand new `CompilationOptions` is in the wrong place, because it uses platform-specific code:

```golang
cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: 0}
```

I suggest to move `SeparateProcessGroup()` to _run_linux.go_ and move corresponding test to the new file with a build-flag.

## Fix #80 

Also there's a new mechanism to process every `exec.Cmd` before it runs.

Client code may differ by platform using build tags. I think that these mutations will be the same within an app. So global package-level setting is quite good and fast fix. Usage example:

```golang
//go:build windows

package pkg

import (
	ffmpeg "github.com/u2takey/ffmpeg-go"
	"os/exec"
	"syscall"
)

func init() {
	ffmpeg.GlobalCommandOptions = append(ffmpeg.GlobalCommandOptions, func(cmd *exec.Cmd) {
		if cmd.SysProcAttr == nil {
			cmd.SysProcAttr = &syscall.SysProcAttr{}
		}
		cmd.SysProcAttr.HideWindow = true
	}) 
}
```

or setpgid for linux:

```golang
//go:build linux

package pkg

import (
	ffmpeg "github.com/u2takey/ffmpeg-go"
	"os/exec"
	"syscall"
)

func init() {
	ffmpeg.GlobalCommandOptions = append(ffmpeg.GlobalCommandOptions, func(cmd *exec.Cmd) {
		if cmd.SysProcAttr == nil {
			cmd.SysProcAttr = &syscall.SysProcAttr{}
		}
		cmd.SysProcAttr.Setpgid = true
		cmd.SysProcAttr.Pgid = 0
	}) 
}
```