### PR TITLE
Suppress compiled command

### DIFF
--- a/run.go
+++ b/run.go
@@ -253,7 +253,12 @@ func (s *Stream) SetFfmpegPath(path string) *Stream {
 	return s
 }
 
-// for test
+var LogCompiledCommand bool = true
+
+func (s *Stream) Silent(isSilent bool) *Stream {
+	LogCompiledCommand = !isSilent
+	return s
+}
 func (s *Stream) Compile(options ...CompilationOption) *exec.Cmd {
 	args := s.GetArgs()
 	cmd := exec.CommandContext(s.Context, s.FfmpegPath, args...)
@@ -269,7 +274,9 @@ func (s *Stream) Compile(options ...CompilationOption) *exec.Cmd {
 	for _, option := range options {
 		option(s, cmd)
 	}
-	log.Printf("compiled command: ffmpeg %s\n", strings.Join(args, " "))
+	if LogCompiledCommand {
+		log.Printf("compiled command: ffmpeg %s\n", strings.Join(args, " "))
+	}
 	return cmd
 }
 


### PR DESCRIPTION
I added an method to disable the logging of the compiled ffmpeg command

this was also a requested feature in #62 