### PR TITLE
fix: unused CompilationOption in `(*Stream) Compile`

### DIFF
--- a/run.go
+++ b/run.go
@@ -268,7 +268,10 @@ func (s *Stream) Compile(options ...CompilationOption) *exec.Cmd {
 	for _, option := range GlobalCommandOptions {
 		option(cmd)
 	}
-  if LogCompiledCommand {
+	for _, option := range options {
+		option(s, cmd)
+	}
+	if LogCompiledCommand {
 		log.Printf("compiled command: ffmpeg %s\n", strings.Join(args, " "))
 	}
 	return cmd


### PR DESCRIPTION
Let me know if this is intentional.

https://github.com/u2takey/ffmpeg-go/blob/898ebfd93985f0f69cde36e466094cd453caa349/run.go#L256-L275